### PR TITLE
default_description and default_address text strings were divided into 2. Please try and comment if such behaviour isvacceptable( specially when device language isnt among supported languages)

### DIFF
--- a/SightLocator/AndroidManifest.xml
+++ b/SightLocator/AndroidManifest.xml
@@ -59,7 +59,7 @@
             android:value="@integer/google_play_services_version" />
         <meta-data
             android:name="com.google.android.maps.v2.API_KEY"
-            android:value="AIzaSyDERwhJ6T1iKo8dmgJgCMgy47_UX5tJvMc" />
+            android:value="AIzaSyBhcTNmKc9tePZs-eiBzQNXHSmkjAi0Nz4" />
         <uses-library android:name="android.test.runner" />
     </application>
     

--- a/SightLocator/res/values-uk/strings.xml
+++ b/SightLocator/res/values-uk/strings.xml
@@ -49,6 +49,8 @@
     <string name="welcome_screen_text">ВІТАЄМО,\nЛюбий Друже! Ми допоможемо тобі знайти місця, в яких прагнеш побувати.</string>
     
     <!-- Default text that is shown when original is absent-->
-    <string name="default_description_text">Опис вибраною мовою не доступний. Оберіть іншу мову</string>
-    <string name="default_address_text">Адреса вибраною мовою не доступна</string>
+    <string name="default_description_text_part1">Опис вибраною мовою(</string>
+    <string name="default_description_text_part2">) не доступний. Оберіть іншу мову</string>
+    <string name="default_address_text_part1">Адреса вибраною мовою(</string>
+    <string name="default_address_text_part2">) не доступна</string>
 </resources>

--- a/SightLocator/res/values/strings.xml
+++ b/SightLocator/res/values/strings.xml
@@ -79,6 +79,9 @@
     <string name="action_filter_monument">Monument</string>
 
     <!-- Default text-->
-    <string name="default_description_text">No available description in current language. Please choose other language</string>
-    <string name="default_address_text">No available address in current language</string>
+    <string name="default_description_text_part1">No available description in current language(</string>
+    <string name="default_description_text_part2">). Please choose other language</string>
+    <string name="default_address_text_part1">No available address in current language(</string>
+    <string name="default_address_text_part2">)</string>
+    
 </resources>

--- a/SightLocator/src/com/iolab/sightlocator/GetTextOnMarkerClickAction.java
+++ b/SightLocator/src/com/iolab/sightlocator/GetTextOnMarkerClickAction.java
@@ -292,14 +292,30 @@ public class GetTextOnMarkerClickAction implements ServiceAction, Parcelable{
 		Pair<String, String> pathType = getImagePathAndSource(pathToImage);
 		
 		if (sightDescription == null) {
-			sightDescription = Appl.appContext.getResources().getString(R.string.default_description_text);
+			sightDescription = Appl.appContext.getResources().getString(
+					R.string.default_description_text_part1)
+					+ Language.getFullLanguageName(mLanguage)
+					+ Appl.appContext.getResources().getString(
+							R.string.default_description_text_part2);
 		} else if (sightDescription.length() == 0) {
-			sightDescription = Appl.appContext.getResources().getString(R.string.default_description_text);
+			sightDescription = Appl.appContext.getResources().getString(
+					R.string.default_description_text_part1)
+					+ Language.getFullLanguageName(mLanguage)
+					+ Appl.appContext.getResources().getString(
+							R.string.default_description_text_part2);
 		}
 		if (sightAddress == null) {
-			sightAddress = Appl.appContext.getResources().getString(R.string.default_address_text);
+			sightAddress = Appl.appContext.getResources().getString(
+					R.string.default_address_text_part1)
+					+ Language.getFullLanguageName(mLanguage)
+					+ Appl.appContext.getResources().getString(
+							R.string.default_address_text_part2);
 		} else if (sightAddress.length() == 0) {
-			sightAddress = Appl.appContext.getResources().getString(R.string.default_address_text);
+			sightAddress = Appl.appContext.getResources().getString(
+					R.string.default_address_text_part1)
+					+ Language.getFullLanguageName(mLanguage)
+					+ Appl.appContext.getResources().getString(
+							R.string.default_address_text_part2);
 		}
 		
 		Bundle resultData = new Bundle();


### PR DESCRIPTION
strings each. mLanguage is used in showing default texts
